### PR TITLE
Merge Keyboard & Gamepad Speed Indicators

### DIFF
--- a/configs/example.json
+++ b/configs/example.json
@@ -3,8 +3,7 @@
 		"ip": "*"
 	},
 	"control": {
-		"default_gamepad_speed": 3,
-		"default_keyboard_speed": 3
+		"default_speed": 3
 	},
 	"motors": {
 		"type": "virtual"

--- a/docs/config_schema.md
+++ b/docs/config_schema.md
@@ -12,13 +12,9 @@ It can be set to '*' to bind to any available address.
 
 ## `control`
 
-`default_gamepad_speed`
+`default_speed`
 
-Default gamepad speed option between 1 and 8.
-
-`default_keyboard_speed`
-
-Default keyboard speed option between 1 and 8.
+Default speed between 1 and 8.
 
 ## `motors`
 

--- a/interface/index.html
+++ b/interface/index.html
@@ -693,10 +693,13 @@
 									</div>
 								</li>
 								<li class="list-group-item">
-									<p style="margin-bottom: 0.5rem;">
+									<div style="margin-bottom: 0.75rem;">
 										<span style="padding-right: 10px;">Keyboard speed</span>
-										<kbd class="float-right">➖/➕</kbd>
-									</p>
+										<div class="float-right btn-group mr-2" role="group">
+											<button class="btn btn-outline-dark btn-sm">➖</button>
+											<button class="btn btn-outline-dark btn-sm">➕</button>
+										</div>
+									</div>
 									<div class="progress">
 										<div id="kb_speed_node_1" class="progress-bar pb-en bg-success">1</div>
 										<div id="kb_speed_node_2" class="progress-bar pb-en bg-success">2</div>

--- a/interface/index.html
+++ b/interface/index.html
@@ -677,21 +677,6 @@
 					<div class="col">
 						<div class="card">
 							<ul id="textgroup_right" class="list-group list-group-flush font-weight-light">
-								<li id="gamepad_speed_indicator" class="list-group-item">
-									<p style="margin-bottom: 0.5rem;">
-										<span style="padding-right: 10px;">Gamepad speed </span>
-										<kbd class="float-right">dpad ◀/▶</kbd></p>
-									<div class="progress">
-										<div id="gp_speed_node_1" class="progress-bar pb-en bg-success">1</div>
-										<div id="gp_speed_node_2" class="progress-bar pb-en bg-success">2</div>
-										<div id="gp_speed_node_3" class="progress-bar pb-en bg-success">3</div>
-										<div id="gp_speed_node_4" class="progress-bar pb-en bg-success">4</div>
-										<div id="gp_speed_node_5" class="progress-bar pb-en bg-success">5</div>
-										<div id="gp_speed_node_6" class="progress-bar pb-dis bg-success">6</div>
-										<div id="gp_speed_node_7" class="progress-bar pb-dis bg-warning">7</div>
-										<div id="gp_speed_node_8" class="progress-bar pb-dis bg-danger">8</div>
-									</div>
-								</li>
 								<li class="list-group-item">
 									<div style="margin-bottom: 0.75rem;">
 										<span style="padding-right: 10px;">Keyboard speed</span>

--- a/interface/index.html
+++ b/interface/index.html
@@ -679,7 +679,7 @@
 							<ul id="textgroup_right" class="list-group list-group-flush font-weight-light">
 								<li class="list-group-item">
 									<div style="margin-bottom: 0.75rem;">
-										<span style="padding-right: 10px;">Keyboard speed</span>
+										<span style="padding-right: 10px;">Drive Speed</span>
 										<div class="float-right btn-group mr-2" role="group">
 											<button id="speed_down" class="btn btn-outline-dark btn-sm">➖</button>
 											<button id="speed_up" class="btn btn-outline-dark btn-sm">➕</button>

--- a/interface/index.html
+++ b/interface/index.html
@@ -686,14 +686,14 @@
 										</div>
 									</div>
 									<div class="progress">
-										<div id="kb_speed_node_1" class="progress-bar pb-en bg-success">1</div>
-										<div id="kb_speed_node_2" class="progress-bar pb-en bg-success">2</div>
-										<div id="kb_speed_node_3" class="progress-bar pb-en bg-success">3</div>
-										<div id="kb_speed_node_4" class="progress-bar pb-en bg-success">4</div>
-										<div id="kb_speed_node_5" class="progress-bar pb-en bg-success">5</div>
-										<div id="kb_speed_node_6" class="progress-bar pb-dis bg-success">6</div>
-										<div id="kb_speed_node_7" class="progress-bar pb-dis bg-warning">7</div>
-										<div id="kb_speed_node_8" class="progress-bar pb-dis bg-danger">8</div>
+										<div id="speed_node_1" class="progress-bar pb-en bg-success">1</div>
+										<div id="speed_node_2" class="progress-bar pb-en bg-success">2</div>
+										<div id="speed_node_3" class="progress-bar pb-en bg-success">3</div>
+										<div id="speed_node_4" class="progress-bar pb-en bg-success">4</div>
+										<div id="speed_node_5" class="progress-bar pb-en bg-success">5</div>
+										<div id="speed_node_6" class="progress-bar pb-dis bg-success">6</div>
+										<div id="speed_node_7" class="progress-bar pb-dis bg-warning">7</div>
+										<div id="speed_node_8" class="progress-bar pb-dis bg-danger">8</div>
 									</div>
 								</li>
 							</ul>

--- a/interface/index.html
+++ b/interface/index.html
@@ -696,8 +696,8 @@
 									<div style="margin-bottom: 0.75rem;">
 										<span style="padding-right: 10px;">Keyboard speed</span>
 										<div class="float-right btn-group mr-2" role="group">
-											<button class="btn btn-outline-dark btn-sm">➖</button>
-											<button class="btn btn-outline-dark btn-sm">➕</button>
+											<button id="speed_down" class="btn btn-outline-dark btn-sm">➖</button>
+											<button id="speed_up" class="btn btn-outline-dark btn-sm">➕</button>
 										</div>
 									</div>
 									<div class="progress">

--- a/interface/js/sights.alert.js
+++ b/interface/js/sights.alert.js
@@ -43,8 +43,6 @@ function gamepadConnectedAlert() {
     // Controller status indicator
     $("#controller_status_connected").show();
     $("#controller_status_disconnected").hide();
-    // Gamepad speed indicator
-    $("#gamepad_speed_indicator").show();
     // Create corresponding toast
     launchToast("Controller connected", "success", "gamepad");
 }

--- a/interface/js/sights.config.schema.js
+++ b/interface/js/sights.config.schema.js
@@ -46,25 +46,14 @@ const schema = {
             "title": "Control",
             "description": "Default settings for controllers.",
             "required": [
-                "default_gamepad_speed",
-                "default_keyboard_speed"
+                "default_speed"
             ],
             "properties": {
-                "default_gamepad_speed": {
-                    "$id": "#/properties/control/properties/default_gamepad_speed",
+                "default_speed": {
+                    "$id": "#/properties/control/properties/default_speed",
                     "type": "integer",
-                    "title": "Default Gamepad Speed",
-                    "description": "The default motor speed (1-8) when using a gamepad.",
-                    "format": "range",
-                    "default": 3,
-                    "minimum": 1.0,
-                    "maximum": 8.0
-                },
-                "default_keyboard_speed": {
-                    "$id": "#/properties/control/properties/default_keyboard_speed",
-                    "type": "integer",
-                    "title": "Default Keyboard Speed",
-                    "description": "The default motor speed (1-8) when using the keyboard.",
+                    "title": "Default Speed",
+                    "description": "The default motor speed (1-8).",
                     "format": "range",
                     "default": 3,
                     "minimum": 1.0,

--- a/interface/js/sights.control.js
+++ b/interface/js/sights.control.js
@@ -131,8 +131,6 @@ $(document).on("ready", function () {
 
 	// Hide 'Controller Connected' indicator, until connected 
 	$("#controller_status_connected").hide();
-	// Hide gamepad speed indicator, until connected
-	$("#gamepad_speed_indicator").hide();
 
 	// Attach it to the window so it can be inspected at the console.
 	window.gamepad = new Gamepad();
@@ -158,7 +156,6 @@ $(document).on("ready", function () {
 
 		if (gamepad.count() == 0) {
 			$("#controller_status_connected").hide();
-			$("#gamepad_speed_indicator").hide();
 			$("#controller_status_disconnected").show();
 		}
 		gamepadDisconnectedAlert();

--- a/interface/js/sights.demo.js
+++ b/interface/js/sights.demo.js
@@ -3,7 +3,7 @@
 	Licensed under the GNU General Public License 3.0
 */
 var demo = false;
-var demo_config = {"network":{"ip":"*"},"control":{"default_gamepad_speed":3,"default_keyboard_speed":3},"motors":{
+var demo_config = {"network":{"ip":"*"},"control":{"default_speed":3},"motors":{
 	"type":"virtual"},"arduino":{"enabled":false},"interface":{"notifications":{"enabled":true,"timeout":7},"cameras":{
 		"front":{"enabled":true,"id":1},"back":{"enabled":true,"id":2},"left":{"enabled":true,"id":3},"right":{
 			"enabled":true,"id":4}},"graphs":[{"uid":"cpu_temperature","type":"circle","enabled":true,"location":
@@ -129,17 +129,17 @@ function demoMode() {
 	};
 	$('#gamepad_monitor_pre').html(hljs.highlight("JSON", JSON.stringify(obj, null, '\t')).value);
 
-	let demo_keyboard_speed = 3;
+	let demo_speed = 3;
 	keyboardJS.bind('-', null, function (e) {
 		// Keep speed at a minimum of 1
-		demo_keyboard_speed = Math.max(1, demo_keyboard_speed - 1);
-		setSpeedIndicator("kb", demo_keyboard_speed);
+		demo_speed = Math.max(1, demo_speed - 1);
+		setSpeedIndicator(demo_speed);
 	});
 
 	keyboardJS.bind('=', null, function (e) {
 		// Keep speed at a max of 8
-		demo_keyboard_speed = Math.min(8, demo_keyboard_speed + 1);
-		setSpeedIndicator("kb", demo_keyboard_speed);
+		demo_speed = Math.min(8, demo_speed + 1);
+		setSpeedIndicator(demo_speed);
 	});
 
 	var example_log = `2019-11-09 13:37:04,068 INFO __main__: Starting manager process

--- a/interface/js/sights.interface.js
+++ b/interface/js/sights.interface.js
@@ -172,14 +172,13 @@ function toggleSensorMode() {
 	}
 }
 
-function setSpeedIndicator(type, speed) {
-	// Type is either 'kb' (keyboard) or 'gp' (gamepad)
+function setSpeedIndicator(speed) {
 	// Given speed (127 to 1023) needs to be between 1 and 8
 	speed = (speed + 1) / 128;
 	// Enables / disables relevant nodes (1 - 8) for speed indicators
 	for (var i = 0; i < 8; i++) {
 		var val = i < speed ? '12.5%' : '0%';
-		$("#" + type + "_speed_node_" + (i + 1)).css('width', val);
+		$("#speed_node_" + (i + 1)).css('width', val);
 	}
 }
 

--- a/interface/js/sights.interface.js
+++ b/interface/js/sights.interface.js
@@ -184,6 +184,14 @@ function setSpeedIndicator(type, speed) {
 }
 
 $(document).on("ready", function () {
+    $("#speed_down").on("click", function () {
+        keyboardJS.pressKey('-');
+        keyboardJS.releaseKey('-');
+    });
+    $("#speed_up").on("click", function () {
+        keyboardJS.pressKey('=');
+        keyboardJS.releaseKey('=');
+    });
 	toggleSensorMode();
 	// Hide update instructions until user checks for an update
 	$('#update_instructions').hide();

--- a/interface/js/sights.sensors.js
+++ b/interface/js/sights.sensors.js
@@ -121,8 +121,7 @@ function sensorUpdate(obj) {
 			global_config = response;
 
 			// Manually set output text of range slider elements
-			$('output', $('#visual_editor_container'))[0].innerText = response['control']['default_gamepad_speed'];
-			$('output', $('#visual_editor_container'))[1].innerText = response['control']['default_keyboard_speed'];
+			$('output', $('#visual_editor_container'))[0].innerText = response['control']['default_speed'];
 
 			// Now handle loading stuff from the config file
 			// Enable / disable cameras and set their ports as defined by the config

--- a/interface/js/sights.sensors.js
+++ b/interface/js/sights.sensors.js
@@ -284,11 +284,8 @@ function sensorUpdate(obj) {
 
 	// Permanent/default "sensors"
 	// Speed indicators for keyboard and gamepad
-	if ("kb_speed" in obj) {
-		setSpeedIndicator("kb", obj["kb_speed"]);
-	}
-	if ("gp_speed" in obj) {
-		setSpeedIndicator("gp", obj["gp_speed"]);
+	if ("speed" in obj) {
+		setSpeedIndicator(obj["speed"]);
 	}
 }
 

--- a/src/configs/sights/minimal.json
+++ b/src/configs/sights/minimal.json
@@ -3,8 +3,7 @@
 		"ip": "*"
 	},
 	"control": {
-		"default_gamepad_speed": 3,
-		"default_keyboard_speed": 3
+		"default_speed": 3
 	},
 	"motors": {
 		"type": "virtual"

--- a/src/control_receiver.py
+++ b/src/control_receiver.py
@@ -30,9 +30,9 @@ class ControlReceiver (WebSocketProcess):
 
     def gamepad_movement_handler(self, type="TRIGGER"):
         if (type == "TRIGGER"):
-            # Set speed range to be from 0 to `gamepad_speed`
-            left = self.state["LEFT_BOTTOM_SHOULDER"] * self.motors.gamepad_speed
-            right = self.state["RIGHT_BOTTOM_SHOULDER"] * self.motors.gamepad_speed
+            # Set speed range to be from 0 to `speed`
+            left = self.state["LEFT_BOTTOM_SHOULDER"] * self.motors.speed
+            right = self.state["RIGHT_BOTTOM_SHOULDER"] * self.motors.speed
 
             # If modifier pressed, then invert value
             left *= (-1) ** self.state["LEFT_TOP_SHOULDER"]
@@ -57,15 +57,15 @@ class ControlReceiver (WebSocketProcess):
             # Clamp to -1/+1
             left = max(-1, min(left, 1))
             right = max(-1, min(right, 1))
-            # Multiply by gamepad_speed to get our final speed to be sent to the servos
-            left *= self.motors.gamepad_speed
-            right *= self.motors.gamepad_speed
+            # Multiply by speed to get our final speed to be sent to the servos
+            left *= self.motors.speed
+            right *= self.motors.speed
             # Send command to servos
             self.motors.move(left, right)
 
 
     def keyboard_handler(self, control, value):
-        speed = self.motors.keyboard_speed
+        speed = self.motors.speed
         if (control == "FORWARD"):
             self.motors.move(speed, speed)
         elif (control == "BACKWARDS"):
@@ -78,14 +78,14 @@ class ControlReceiver (WebSocketProcess):
             self.motors.move(0, 0)
         elif (control == "SPEED_UP"):
             if value == "DOWN":
-                self.motors.keyboard_speed = min(1023, speed + 128)
+                self.motors.speed = min(1023, speed + 128)
                 # Send a message to SensorStream to update the interface with the current speed
-                self.pipe.send(["SYNC_SPEED", "kb", self.motors.keyboard_speed])
+                self.pipe.send(["SYNC_SPEED", self.motors.speed])
         elif (control == "SPEED_DOWN"):
             if value == "DOWN":
-                self.motors.keyboard_speed = max(127, speed - 128)
+                self.motors.speed = max(127, speed - 128)
                 # Send a message to SensorStream to update the interface with the current speed
-                self.pipe.send(["SYNC_SPEED", "kb", self.motors.keyboard_speed])
+                self.pipe.send(["SYNC_SPEED", self.motors.speed])
 
 
     def message_handler(self, buf):
@@ -109,12 +109,12 @@ class ControlReceiver (WebSocketProcess):
             # Then handle any button events
             if control == "DPAD_LEFT":
                 if value == "DOWN":
-                    self.motors.gamepad_speed = min(1023, self.motors.gamepad_speed + 128)
-                    self.pipe.send(["SYNC_SPEED", "gp", self.motors.gamepad_speed])
+                    self.motors.speed = min(1023, self.motors.speed + 128)
+                    self.pipe.send(["SYNC_SPEED", self.motors.speed])
             elif control == "DPAD_RIGHT":
                 if value == "DOWN":
-                    self.motors.gamepad_speed = max(127, self.motors.gamepad_speed - 128)
-                    self.pipe.send(["SYNC_SPEED", "gp", self.motors.gamepad_speed])
+                    self.motors.speed = max(127, self.motors.speed - 128)
+                    self.pipe.send(["SYNC_SPEED", self.motors.speed])
         elif typ == "AXIS":
             # If axis, store as float
             value = float(msg["value"])

--- a/src/motor_handler.py
+++ b/src/motor_handler.py
@@ -32,8 +32,7 @@ class Motors:
             self.connection = VirtualConnection(config['motors'])
             self.type = 'virtual'
         # Load speed defaults
-        self.gamepad_speed = config['control']['default_gamepad_speed'] * 128 - 1
-        self.keyboard_speed = config['control']['default_keyboard_speed'] * 128 - 1
+        self.speed = config['control']['default_speed'] * 128 - 1
         self.last_left = 0
         self.last_right = 0
         # Ensure Connection class has access to logging capabilities

--- a/src/sensor_stream.py
+++ b/src/sensor_stream.py
@@ -115,15 +115,15 @@ class SensorStream(WebSocketProcess):
     async def pipe_message_handler(self, msg):
         # If we receive a message from ControLReceiver with a new speed, set that to our speed
         if msg[0] == "SYNC_SPEED":
-            await self.send_speed_value(msg[1], msg[2])
+            await self.send_speed_value(msg[1])
 
-    async def send_speed_value(self, typ, speed):
+    async def send_speed_value(self, speed):
         msg = {}
         # Create message with type and value of the speed
-        msg[typ + "_speed"] = speed
+        msg["speed"] = speed
         # Send current speed to be displayed on the interface
         await self.websocket.send(json.dumps(msg))
-        self.logger.debug("Syncronized speed setting")
+        self.logger.debug("Synchronised speed setting")
 
     async def send_init_info(self):
         msg = {}

--- a/src/sensor_stream.py
+++ b/src/sensor_stream.py
@@ -131,8 +131,7 @@ class SensorStream(WebSocketProcess):
         msg["running_config"] = os.path.basename(self.config_file)
         # Even though these are part of the config object, we send them seperately
         # Since we don't want the speed resetting every time we edit the config 
-        msg["kb_speed"] = self.config['control']['default_keyboard_speed'] * 128 - 1
-        msg["gp_speed"] = self.config['control']['default_gamepad_speed'] * 128 - 1
+        msg["speed"] = self.config['control']['default_speed'] * 128 - 1
         # System uptime, as time in seconds since boot
         with open('/proc/uptime', 'r') as f:
             msg["uptime"] = round(float(f.readline().split()[0]))


### PR DESCRIPTION
# Description

- Consolidates the separate references to keyboard and gamepad controlled motor speeds into a single speed.
- Reduces interface complexity by removing an unnecessary duplicate indicator.
- Adds mouse button control for speed in the interface

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Re-write of an existing feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Testing

Tested the new mouse button speed changing features as well as the existing keyboard speed change.

Tested with Dynamixel servos to verify the changes to the Python code.

Someone else may need to test with a gamepad as I don't have one as I am not a peasant.

# Final checklist:

- [x] Code follows the style guidelines of SIGHTS
- [x] I have performed a self-review of my own code
- [x] Comments have been added, particularly in hard-to-understand areas
- [x] Made corresponding changes to the documentation
- [x] The changes cause no new errors or warnings
